### PR TITLE
Enable mobile access and responsive layout

### DIFF
--- a/russian-focus/src/components/Flashcards.jsx
+++ b/russian-focus/src/components/Flashcards.jsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { DeckPicker } from './DeckPicker.jsx'
 
 // JSON schema for cards in a deck:

--- a/russian-focus/src/components/LessonList.jsx
+++ b/russian-focus/src/components/LessonList.jsx
@@ -1,30 +1,13 @@
 
 import React, { useEffect, useState } from 'react'
 import lessonsNorwegian from '../data/lessons.json'
+import lessonsKorean from '../data/lessons-korean.json'
 import { TTSButton } from './TTSButton.jsx'
-
-// Dynamically import Korean lessons with fallback
-let lessonsKorean = lessonsNorwegian // Fallback to Norwegian
-try {
-  lessonsKorean = require('../data/lessons-korean.json')
-} catch (error) {
-  console.warn('Korean lessons not available, using Norwegian as fallback')
-  lessonsKorean = lessonsNorwegian
-}
 
 export function LessonList({ showHints, selectedUser }) {
   // Choose the appropriate lessons data based on selected user
-  let lessons = lessonsNorwegian // Default to Norwegian lessons
-  
-  try {
-    if (selectedUser?.id === 'jaeyoon') {
-      lessons = lessonsKorean
-    }
-  } catch (error) {
-    console.error('Error loading lessons:', error)
-    lessons = lessonsNorwegian // Fallback to Norwegian
-  }
-  
+  const lessons = selectedUser?.id === 'jaeyoon' ? lessonsKorean : lessonsNorwegian
+
   console.log('Using lessons data:', lessons?.length, 'lessons for user:', selectedUser?.name)
   
   const [openId, setOpenId] = useState(localStorage.getItem('openLesson') || lessons[0]?.id || 1)

--- a/russian-focus/src/components/Pomodoro.jsx
+++ b/russian-focus/src/components/Pomodoro.jsx
@@ -21,7 +21,7 @@ export function Pomodoro() {
       setMode(nextMode)
       const next = (nextMode === 'work' ? workLen : breakLen) * 60
       setSeconds(next)
-      try { new AudioContext() } catch {}
+      try { new AudioContext() } catch { /* ignore */ }
       if ('speechSynthesis' in window) {
         const u = new SpeechSynthesisUtterance(nextMode === 'work' ? 'Back to work' : 'Take a short break')
         u.lang = 'en-US'

--- a/russian-focus/src/styles/global.css
+++ b/russian-focus/src/styles/global.css
@@ -256,3 +256,51 @@ button, input { font: inherit; }
 }
 .deck-card__title { font-weight: 700; margin-bottom: 6px; }
 .deck-card__meta { color: var(--muted); }
+
+/* Mobile layout adjustments */
+@media (max-width: 600px) {
+  .app__header {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
+    gap: 8px;
+  }
+
+  .app__nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .app__tools {
+    justify-content: flex-start;
+  }
+
+  .lessons {
+    grid-template-columns: 1fr;
+  }
+
+  .lessons__menu {
+    position: static;
+    top: auto;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  .phrase-list li {
+    grid-template-columns: 1fr;
+  }
+
+  .phrase-list .en,
+  .phrase-list .tools {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .phrase-list .tools {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+  }
+}

--- a/russian-focus/vite.config.js
+++ b/russian-focus/vite.config.js
@@ -4,4 +4,10 @@ import react from '@vitejs/plugin-react-swc'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+  },
+  preview: {
+    host: true,
+  },
 })


### PR DESCRIPTION
## Summary
- allow Vite dev and preview servers to listen on the network so the site is accessible from phones
- add mobile-friendly layout rules for header, lessons menu, and phrase list
- simplify lesson loading and clean up unused code to satisfy lint checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895cf8e6b50832282e6ff623b79b056